### PR TITLE
Update exampledata to 7.0.0 for Vaadin 25.1 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>exampledata</artifactId>
-            <version>6.2.0</version>
+            <version>7.0.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary

- Update exampledata from 6.2.0 to 7.0.0
- exampledata 6.x references `FrontendUtils` from its old location (`com.vaadin.flow.server.frontend`), which was moved to `com.vaadin.flow.internal` in Flow 25.1
- Fixes `NoClassDefFoundError: com.vaadin.flow.server.frontend.FrontendUtils` at startup